### PR TITLE
Add minimal GH Action support.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,4 +14,4 @@ jobs:
           mkdir build
           cd build
           cmake ..
-          cmake --build
+          cmake --build .

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,17 @@
+name: Build
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        os: [macos-latest, windows-latest]
+    runs-on: ${{matrix.os}}
+    steps:
+      - uses: actions/checkout@v4
+      - run: |
+          mkdir build
+          cd build
+          cmake ..
+          cmake --build


### PR DESCRIPTION
Just a small GH Action workflow file to build for the desktop platforms on push and pull requests.

Not sure if you want that, but I feel always a bit better at least in pull requests when the CI goes green to avoid any "works on my machine" problems.

Looks like this: https://github.com/floooh/demo-pd-cranktheworld/actions/runs/9212275256