### PR TITLE
Add Emscripten support.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,5 +18,23 @@ jobs:
       - run: |
           mkdir build
           cd build
-          cmake ..
+          cmake -DCMAKE_BUILD_TYPE=Debug ..
+          cmake --build .
+          cmake -DCMAKE_BUILD_TYPE=Release ..
+          cmake --build .
+  emscripten:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: prepare
+        run: |
+          git clone https://github.com/emscripten-core/emsdk
+          ./emsdk install 3.1.60
+          ./emsdk activate 3.1.60
+          cd ..
+      - name: build
+        run: |
+          mkdir build
+          cd build
+          cmake --preset emscripten-release ..
           cmake --build .

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,6 +29,7 @@ jobs:
       - name: prepare
         run: |
           git clone https://github.com/emscripten-core/emsdk
+          cd emsdk
           ./emsdk install 3.1.60
           ./emsdk activate 3.1.60
           cd ..

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,5 +37,7 @@ jobs:
         run: |
           mkdir build
           cd build
+          cmake --preset emscripten-debug ..
+          cmake --build .
           cmake --preset emscripten-release ..
           cmake --build .

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,9 +19,9 @@ jobs:
           mkdir build
           cd build
           cmake -DCMAKE_BUILD_TYPE=Debug ..
-          cmake --build .
+          cmake --build . --clean-first
           cmake -DCMAKE_BUILD_TYPE=Release ..
-          cmake --build .
+          cmake --build . --clean-first
   emscripten:
     runs-on: ubuntu-latest
     steps:
@@ -38,6 +38,6 @@ jobs:
           mkdir build
           cd build
           cmake --preset emscripten-debug ..
-          cmake --build .
+          cmake --build . --clean-first
           cmake --preset emscripten-release ..
-          cmake --build .
+          cmake --build . --clean-first

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,30 @@
+# manually triggered script to build and deploy the web version to github pages
+name: Deploy Web Demo
+on: workflow_dispatch
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: prepare
+        run: |
+          git clone https://github.com/emscripten-core/emsdk
+          cd emsdk
+          ./emsdk install 3.1.60
+          ./emsdk activate 3.1.60
+          cd ..
+      - name: build
+        run: |
+          mkdir build
+          cd build
+          cmake --preset emscripten-release ..
+          cmake --build .
+          mkdir web
+          cp *.wasm *.html *.js web
+      - name: upload-artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: webpage
+          path: build/web
+          retention-days: 1

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,6 +2,15 @@
 name: Deploy Web Demo
 on: workflow_dispatch
 
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -20,6 +29,7 @@ jobs:
           cd build
           cmake --preset emscripten-release ..
           cmake --build .
+          mv Nesnausk_CrankTheWorld.html index.html
           mkdir web
           cp *.wasm *.html *.js web
       - name: upload-artifact
@@ -28,3 +38,24 @@ jobs:
           name: webpage
           path: build/web
           retention-days: 1
+
+  deploy:
+    needs: build
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: setup-pages
+        uses: actions/configure-pages@v5
+      - name: download-artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: webpage
+      - name: upload-artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: '.'
+      - name: deploy-gh-pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 pdex.dll
 pdex.elf
 .DS_Store
+emsdk/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,16 @@ if(("${BUILD_PLATFORM}" STREQUAL "PLAYDATE") OR ("${BUILD_PLATFORM}" STREQUAL "P
 else()
 	set(IS_PLAYDATE_OR_SIM FALSE)
 endif()
+if (CMAKE_SYSTEM_NAME STREQUAL Emscripten)
+	set(EMSCRIPTEN TRUE)
+else()
+	set(EMSCRIPTEN FALSE)
+endif()
+if (CMAKE_SYSTEM_NAME STREQUAL Linux)
+	set(LINUX TRUE)
+else()
+	set(LINUX FALSE)
+endif()
 
 # Figure out Playdate SDK location
 if (IS_PLAYDATE_OR_SIM)
@@ -111,11 +121,14 @@ else()
 			"-framework MetalKit"
 			"-framework AudioToolbox"
 			"-framework QuartzCore")
-	elseif (CMAKE_SYSTEM_NAME STREQUAL Linux)
+	elseif (LINUX)
 		set(THREADS_PREFER_PTHREADS_FLAG ON)
 		find_package(Threads REQUIRED)
 		target_compile_options(${PLAYDATE_GAME_NAME} PRIVATE -Wno-format-truncation)
 		target_link_libraries(${PLAYDATE_GAME_NAME} PRIVATE X11 Xi Xcursor GL asound dl m Threads::Threads)
+	elseif (EMSCRIPTEN)
+		set(CMAKE_EXECUTABLE_SUFFIX .html)
+		target_link_options(${PLAYDATE_GAME_NAME} PRIVATE -sUSE_WEBGL2=1)
 	endif()
 
 	if(APPLE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -128,10 +128,15 @@ else()
 		target_link_libraries(${PLAYDATE_GAME_NAME} PRIVATE X11 Xi Xcursor GL asound dl m Threads::Threads)
 	elseif (EMSCRIPTEN)
 		set(CMAKE_EXECUTABLE_SUFFIX .html)
+		target_compile_options(${PLAYDATE_GAME_NAME} PRIVATE -flto)
 		target_link_options(${PLAYDATE_GAME_NAME} PRIVATE
+			-flto
 			-sUSE_WEBGL2=1
 			-sALLOW_MEMORY_GROWTH=1
-			--embed-file data)
+			-sMALLOC=emmalloc
+			--embed-file data
+			--shell-file=../web/shell.html
+			--closure 1)
 	endif()
 
 	if(APPLE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -128,7 +128,10 @@ else()
 		target_link_libraries(${PLAYDATE_GAME_NAME} PRIVATE X11 Xi Xcursor GL asound dl m Threads::Threads)
 	elseif (EMSCRIPTEN)
 		set(CMAKE_EXECUTABLE_SUFFIX .html)
-		target_link_options(${PLAYDATE_GAME_NAME} PRIVATE -sUSE_WEBGL2=1)
+		target_link_options(${PLAYDATE_GAME_NAME} PRIVATE
+			-sUSE_WEBGL2=1
+			-sALLOW_MEMORY_GROWTH=1
+			--embed-file data)
 	endif()
 
 	if(APPLE)
@@ -138,12 +141,12 @@ else()
 	endif()
 
 	add_custom_command(
-		TARGET ${PLAYDATE_GAME_NAME} POST_BUILD
+		TARGET ${PLAYDATE_GAME_NAME} PRE_LINK
 		COMMAND ${CMAKE_COMMAND} -E make_directory
 		$<TARGET_FILE_DIR:${PLAYDATE_GAME_NAME}>/${DATA_DIR}
 	)
 	add_custom_command(
-		TARGET ${PLAYDATE_GAME_NAME} POST_BUILD
+		TARGET ${PLAYDATE_GAME_NAME} PRE_LINK
 		COMMAND ${CMAKE_COMMAND} -E copy
 		${CMAKE_CURRENT_SOURCE_DIR}/Source/sys_img/icon.png
 		${CMAKE_CURRENT_SOURCE_DIR}/Source/music.wav

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,12 +14,12 @@ if(("${BUILD_PLATFORM}" STREQUAL "PLAYDATE") OR ("${BUILD_PLATFORM}" STREQUAL "P
 else()
 	set(IS_PLAYDATE_OR_SIM FALSE)
 endif()
-if (CMAKE_SYSTEM_NAME STREQUAL Emscripten)
+if (CMAKE_SYSTEM_NAME STREQUAL "Emscripten")
 	set(EMSCRIPTEN TRUE)
 else()
 	set(EMSCRIPTEN FALSE)
 endif()
-if (CMAKE_SYSTEM_NAME STREQUAL Linux)
+if (CMAKE_SYSTEM_NAME STREQUAL "Linux")
 	set(LINUX TRUE)
 else()
 	set(LINUX FALSE)
@@ -128,15 +128,16 @@ else()
 		target_link_libraries(${PLAYDATE_GAME_NAME} PRIVATE X11 Xi Xcursor GL asound dl m Threads::Threads)
 	elseif (EMSCRIPTEN)
 		set(CMAKE_EXECUTABLE_SUFFIX .html)
-		target_compile_options(${PLAYDATE_GAME_NAME} PRIVATE -flto)
 		target_link_options(${PLAYDATE_GAME_NAME} PRIVATE
-			-flto
 			-sUSE_WEBGL2=1
 			-sALLOW_MEMORY_GROWTH=1
 			-sMALLOC=emmalloc
 			--embed-file data
-			--shell-file=../web/shell.html
-			--closure 1)
+			--shell-file=../web/shell.html)
+		if (CMAKE_BUILD_TYPE STREQUAL "Release")
+			target_compile_options(${PLAYDATE_GAME_NAME} PRIVATE -flto)
+			target_link_options(${PLAYDATE_GAME_NAME} PRIVATE -flto --closure 1)
+		endif()
 	endif()
 
 	if(APPLE)

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -30,10 +30,10 @@
         {
             "name": "pdsim-debug",
             "displayName": "x64 Debug (PlaydateSim)",
-            "inherits": "x64-debug",            
+            "inherits": "x64-debug",
             "cacheVariables": {
                 "BUILD_PLATFORM": "PLAYDATE_SIM"
-            }            
+            }
         },
         {
             "name": "pdsim-release",
@@ -41,16 +41,16 @@
             "inherits": "x64-release",
             "cacheVariables": {
                 "BUILD_PLATFORM": "PLAYDATE_SIM"
-            }            
+            }
         },
         {
             "name": "pd-debug",
             "displayName": "x64 Debug (Playdate)",
-            "inherits": "x64-debug",            
+            "inherits": "x64-debug",
             "toolchainFile": "$env{PLAYDATE_SDK_PATH}/C_API/buildsupport/arm.cmake",
             "cacheVariables": {
                 "BUILD_PLATFORM": "PLAYDATE"
-            }            
+            }
         },
         {
             "name": "pd-release",
@@ -59,7 +59,28 @@
             "toolchainFile": "$env{PLAYDATE_SDK_PATH}/C_API/buildsupport/arm.cmake",
             "cacheVariables": {
                 "BUILD_PLATFORM": "PLAYDATE"
-            }            
+            }
+        },
+        {
+            "name": "emscripten-base",
+            "hidden": true,
+            "toolchainFile": "emsdk/upstream/emscripten/cmake/Modules/Platform/Emscripten.cmake"
+        },
+        {
+            "name": "emscripten-debug",
+            "displayName": "Emscripten Debug",
+            "inherits": "emscripten-base",
+            "cacheVariables": {
+                "CMAKE_BUILD_TYPE": "Debug"
+            }
+        },
+        {
+            "name": "emscripten-release",
+            "displayName": "Emscripten Release",
+            "inherits": "emscripten-base",
+            "cacheVariables": {
+                "CMAKE_BUILD_TYPE": "Release"
+            }
         }
     ]
 }

--- a/readme.md
+++ b/readme.md
@@ -101,10 +101,6 @@ Finally run the build result via
 ../emsdk/upstream/emscripten/emrun Nesnausk_CrankTheWorld.html
 ```
 
-You may need to click/tap into the browser for the audio or even whole demo
-to start (more recent Safari versions seem to freeze the whole application
-until the audio context is resumed via a click).
-
 ### License
 
 Everything I wrote myself is Unlicense / Public Domain. However some 3rd party libraries are used too:

--- a/readme.md
+++ b/readme.md
@@ -54,6 +54,7 @@ The demo can be built for several "platforms":
 - Playdate device itself,
 - Playdate SDK simulator,
 - Regular PC (Windows/Mac/Linux) binary. This one does not require having Playdate or the SDK for it.
+- Web via Emscripten (see separate build instructions below)
 
 On Windows / Visual Studio, easiest is opening the folder directly from within VS. Then pick one of the configuration configs and build.
 The actual Playdate (and simulator) builds I only tried on Windows. They may or might not work when done on other host platforms.
@@ -68,6 +69,41 @@ cmake --build . --config Release
 
 On Linux, you might need to have these installed: `libglu1-mesa-dev`, `mesa-common-dev`, `xorg-dev`, `libasound-dev`.
 
+### Building for Emscripten
+
+Building for Emscripten is best done on macOS or Linux. For Windows, cmake might need to be instructed to use the
+"UNIX Makefiles" or "Ninja" generator.
+
+First setup the Emscripten SDK into the root of the project directory:
+
+```
+git clone https://github.com/emscripten-core/emsdk
+cd emsdk
+./emsdk install 3.1.60
+./emsdk activate 3.1.60
+cd ..
+```
+
+...back in the project root directory:
+
+```
+mkdir build
+cd build
+cmake --preset emscripten-release ..
+cmake --build .
+```
+
+...this will build 3 files (Nesnausk_CrankTheWorld.wasm/.html/.js).
+
+Finally run the build result via
+
+```
+../emsdk/upstream/emscripten/emrun Nesnausk_CrankTheWorld.html
+```
+
+You may need to click/tap into the browser for the audio or even whole demo
+to start (more recent Safari versions seem to freeze the whole application
+until the audio context is resumed via a click).
 
 ### License
 

--- a/src/platform.c
+++ b/src/platform.c
@@ -676,6 +676,14 @@ static void sapp_frame(void)
 {
 	app_update();
 
+	#if defined(__EMSCRIPTEN__)
+	if (saudio_suspended()) {
+		if (0 == (sapp_frame_count() & (1<<5))) {
+			draw_text("click/tap to start", (400 - (18*8)) / 2, (240 - 7) / 2);
+		}
+	}
+	#endif
+
 	sg_update_image(sok_image, &(sg_image_data){.subimage[0][0] = SG_RANGE(s_screen_buffer)});
 
 	sg_begin_pass(&(sg_pass) { .action = sok_pass, .swapchain = sglue_swapchain() });

--- a/src/platform.c
+++ b/src/platform.c
@@ -181,6 +181,8 @@ int eventHandler(PlaydateAPI* pd, PDSystemEvent event, uint32_t arg)
 #define SOKOL_METAL
 #elif defined(_WIN32)
 #define SOKOL_D3D11
+#elif defined(__EMSCRIPTEN__)
+#define SOKOL_GLES3
 #else
 #define SOKOL_GLCORE
 #endif
@@ -548,8 +550,11 @@ static const char* kSokolVertexSource =
 "    return o;\n"
 "}\n";
 #else
-// GLSL
+#ifdef SOKOL_GLCORE
 "#version 410\n"
+#else
+"#version 300 es\n"
+#endif
 "out vec2 uv;\n"
 "void main() {\n"
 "  uv = vec2((gl_VertexID << 1) & 2, gl_VertexID & 2);\n"
@@ -584,18 +589,23 @@ static const char* kSokolFragSource =
 "  return col;\n"
 "}\n";
 #else
-// GLSL
+#ifdef SOKOL_GLCORE
 "#version 410\n"
+#else
+"#version 300 es\n"
+"precision highp float;\n"
+"precision highp int;\n"
+#endif
 "uniform sampler2D tex;\n"
 "in vec2 uv;\n"
 "out vec4 frag_color;\n"
 "void main() {\n"
-"  int x = int(uv.x * 400);\n"
-"  int y = int(uv.y * 240);\n"
+"  int x = int(uv.x * 400.0);\n"
+"  int y = int(uv.y * 240.0);\n"
 "  float pix = texelFetch(tex, ivec2(x>>3, y), 0).x;\n"
 "  uint val = uint(pix * 255.5);\n"
-"  uint mask = 1 << (7 - (x & 7));\n"
-"  frag_color = ((val & mask) != 0) ? vec4(0.694, 0.686, 0.659, 1.0) : vec4(0.192, 0.184, 0.157, 1.0);\n"
+"  uint mask = uint(1 << (7 - (int(x) & 7)));\n"
+"  frag_color = ((val & mask) != 0u) ? vec4(0.694, 0.686, 0.659, 1.0) : vec4(0.192, 0.184, 0.157, 1.0);\n"
 "}\n";
 #endif
 

--- a/web/shell.html
+++ b/web/shell.html
@@ -1,0 +1,56 @@
+<head>
+    <meta charset="UTF-8"/>
+    <title>Crank The World</title>
+    <style type="text/css">
+    .game {
+        position: absolute;
+        top: 0px;
+        left: 0px;
+        margin: 0px;
+        border: 0;
+        width: 100%;
+        height: 100%;
+        overflow: hidden;
+        display: block;
+        image-rendering: optimizeSpeed;
+        image-rendering: -moz-crisp-edges;
+        image-rendering: -o-crisp-edges;
+        image-rendering: -webkit-optimize-contrast;
+        image-rendering: optimize-contrast;
+        image-rendering: crisp-edges;
+        image-rendering: pixelated;
+        -ms-interpolation-mode: nearest-neighbor;
+    }
+    </style>
+</head>
+<body style="background:black">
+  <canvas class="game" id="canvas" oncontextmenu="event.preventDefault()"></canvas>
+  <script type="text/javascript">
+    var Module = {
+        preRun: [],
+        postRun: [],
+        print: (function() {
+            return function(text) {
+                text = Array.prototype.slice.call(arguments).join(' ');
+                console.log(text);
+            };
+        })(),
+        printErr: function(text) {
+            text = Array.prototype.slice.call(arguments).join(' ');
+            console.error(text);
+        },
+        canvas: (function() {
+            var canvas = document.getElementById('canvas');
+            canvas.addEventListener("webglcontextlost", function(e) { alert('FIXME: WebGL context lost, please reload the page'); e.preventDefault(); }, false);
+            return canvas;
+        })(),
+        setStatus: function(text) { },
+        monitorRunDependencies: function(left) { },
+    };
+    window.onerror = function(event) {
+        console.log("onerror: " + event.message);
+    };
+  </script>
+  {{{ SCRIPT }}}
+</body>
+</html>


### PR DESCRIPTION
Makes the demo run in browsers, plus build system / CI scaffolding.

The asset files are bundled into the WASM blob and accessed through the Emscripten virtual filesystem, this allows to keep the synchronous file loading calls in place.

One thing I'm wondering: is the demo's render timing coupled to the audio output somehow to synchronize rendering with audio? When running on the web, the demo doesn't start until the WebAudio context gets activated (on sokol_audio.h this happens on a tap or click into the page).

Looks like this: https://floooh.github.io/demo-pd-cranktheworld/

- a new section with build instructions for the web version in the readme
- two new cmake presets for the debug and release Emscripten build
- changes to CMakeLists.txt for the Emscripten version
- GH Actions: the regular build.yml file now builds both the debug and release version on all target platforms, and a separate Emscripten build job has been added
- a new manually triggered GH Action workflow to build and deploy the web version (this should then show up under https://aras-p.github.io/demo-pd-cranktheworld/
- modified the GLSL shader so that it also compiles under the stricter WebGL2 shader compiler (mainly adding explicit casting)
- added a 'click/tap to start' message only on the Emscripten build as long as the WebAudio is inactive

~~I'll need to check whether the Linux version still works (because of the changes to the GLSL shader code.~~ (ok Linux version still working)

### How to deploy the web version.

Theoretically it should be enough to go the Github Action tab and start the "Deploy Web Page" pipeline (just use the "main" branch instead of "emscripten")

![image](https://github.com/aras-p/demo-pd-cranktheworld/assets/1699414/e004355f-6978-4857-9870-ec9f6cf6028c)

If that fails, maybe the GH Pages features also needs to be enabled in the project settings.

If the pipeline is successful, the demo should be available here:

https://aras-p.github.io/demo-pd-cranktheworld/

